### PR TITLE
Add compatibility for older IE versions

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -19,8 +19,17 @@ class QuillPasteSmart extends Clipboard {
         e.preventDefault();
         const range = this.quill.getSelection();
 
-        const text = e.clipboardData.getData('text/plain');
-        let html = e.clipboardData.getData('text/html');
+        let text;
+        let html;
+
+        if ((!e.clipboardData || !e.clipboardData.getData) &&
+           (window.clipboardData && window.clipboardData.getData)) {
+            // compatibility with older IE versions
+            text = window.clipboardData.getData('Text');
+        } else {
+            text = e.clipboardData.getData('text/plain');
+            html = e.clipboardData.getData('text/html');
+        }
 
         let delta = new Delta().retain(range.index).delete(range.length);
 


### PR DESCRIPTION
We came across this error in our application while using the `quill-paste-smart` package inside an Outlook Add-In. Outlook still forces the use of Internet Explorer in some cases.

In some versions of IE, the `clipboardData` is attached to `window`, not to the `event`. This change checks for those cases. If the event has the right attribute, it will still proceed with the current implementation. 