### PR TITLE
feat: image paste callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ const options = {
                     console.log(node);
                 },
             },
+
+            handleImagePaste(image) {
+                console.log("Image file pasted", image);
+            }
         },
     },
 };
@@ -83,14 +87,15 @@ new Quill('#editor', options);
 
 #### Configuration Object
 
-| key | valid values | default value | type | description |
-|:------| :------: | :------: | :------: |:------|
-| allowed.tags | HTML tags | `undefined` | `Array<string>` | Here you can define any HTML tag that should be allowed to be pasted. If this setting is not specified, allowed tags are determined by possible formats in the toolbar |
-| allowed.attributes | HTML attributes | `undefined` | `Array<string>` | Here you can define any HTML attributes that should be allowed to be pasted. If this setting is not specified, allowed attributes are determined by possible formats in the toolbar |
-| substituteBlockElements | `true` `false` | `true` | `Boolean` | If this setting is set to `true` all forbidden block type tags will be substituted by one of the allowed tags `p`/`div`/`section` |
-| keepSelection | `true` `false` | `false` | `Boolean` | If this setting is set to `true` the pasted content will be selected after pasting it. Otherwise the cursor will be placed right after the pasted content |
-| magicPasteLinks | `true` `false` | `false` | `Boolean` | If this setting is set to `true` pasted URLs over selected text will be converted to an `a` tag. Example: If you select the word `foo` and paste the URL `https://foo.bar/` the result will be `<a href="https://foo.bar/">foo</a>`. Note: This only works if there is nothing pasted except a valid URL. |
-| hooks | [DOMPurify Hooks](https://github.com/cure53/DOMPurify#hooks) | `undefined` | `Array<function>` | Here you can define any of the DOMPurify hooks. This can be handy if you need to cusomtize the HTML sanitizer. For more information see the [hook demos](https://github.com/cure53/DOMPurify/tree/main/demos) from DOMPurify.<br>**BE AWARE**<br>Here you can mess up things. E.g. You could create an infinite loop by adding not allowed tags to the node. |
+| key                     |                         valid values                         | default value |       type        | description                                                                                                                                                                                                                                                                                                                                                  |
+| :---------------------- | :----------------------------------------------------------: | :-----------: | :---------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| allowed.tags            |                          HTML tags                           |  `undefined`  |  `Array<string>`  | Here you can define any HTML tag that should be allowed to be pasted. If this setting is not specified, allowed tags are determined by possible formats in the toolbar                                                                                                                                                                                       |
+| allowed.attributes      |                       HTML attributes                        |  `undefined`  |  `Array<string>`  | Here you can define any HTML attributes that should be allowed to be pasted. If this setting is not specified, allowed attributes are determined by possible formats in the toolbar                                                                                                                                                                          |
+| substituteBlockElements |                        `true` `false`                        |    `true`     |     `Boolean`     | If this setting is set to `true` all forbidden block type tags will be substituted by one of the allowed tags `p`/`div`/`section`                                                                                                                                                                                                                            |
+| keepSelection           |                        `true` `false`                        |    `false`    |     `Boolean`     | If this setting is set to `true` the pasted content will be selected after pasting it. Otherwise the cursor will be placed right after the pasted content                                                                                                                                                                                                    |
+| magicPasteLinks         |                        `true` `false`                        |    `false`    |     `Boolean`     | If this setting is set to `true` pasted URLs over selected text will be converted to an `a` tag. Example: If you select the word `foo` and paste the URL `https://foo.bar/` the result will be `<a href="https://foo.bar/">foo</a>`. Note: This only works if there is nothing pasted except a valid URL.                                                    |
+| hooks                   | [DOMPurify Hooks](https://github.com/cure53/DOMPurify#hooks) |  `undefined`  | `Array<function>` | Here you can define any of the DOMPurify hooks. This can be handy if you need to cusomtize the HTML sanitizer. For more information see the [hook demos](https://github.com/cure53/DOMPurify/tree/main/demos) from DOMPurify.<br>**BE AWARE**<br>Here you can mess up things. E.g. You could create an infinite loop by adding not allowed tags to the node. |
+| handleImagePaste        |                      `function (File)`                       |  `undefined`  | `function (File)` | Here you can define custom behavior for handling images being pasted, you can use this to upload the image to a CDN rather than embedding                                                                                                                                                                                                                    |
 
 <br>
 

--- a/src/module.js
+++ b/src/module.js
@@ -13,6 +13,7 @@ class QuillPasteSmart extends Clipboard {
     this.substituteBlockElements = options.substituteBlockElements;
     this.magicPasteLinks = options.magicPasteLinks;
     this.hooks = options.hooks;
+    this.handleImagePaste = options.handleImagePaste;
   }
 
   onPaste(e) {
@@ -55,13 +56,18 @@ class QuillPasteSmart extends Clipboard {
       file && file.kind === 'file' && file.type.match(/^image\//i)
     ) {
       const image = file.getAsFile()
-      const reader = new FileReader()
-      reader.onload = (e) => {
-        this.quill.insertEmbed(range.index, 'image', e.target.result)
-        // if required, manually update the selection after the file loads
-        if (!this.keepSelection) this.quill.setSelection(range.index + 1)
+
+      if (this.handleImagePaste !== undefined) {
+        this.handleImagePaste(image);
+      } else {
+        const reader = new FileReader()
+        reader.onload = (e) => {
+          this.quill.insertEmbed(range.index, 'image', e.target.result)
+          // if required, manually update the selection after the file loads
+          if (!this.keepSelection) this.quill.setSelection(range.index + 1)
+        }
+        reader.readAsDataURL(image)
       }
-      reader.readAsDataURL(image)
     } else {
 
       if (!html) {


### PR DESCRIPTION
## Description 

Adds a "handleImagePaste" callback to the options which allows handling when an image is pasted so it can be uploaded to a CDN or handled in some different way than directly embedding. The default behavior is used when the callback is not specified

## Changes

- Adds a "handleImagePaste" callback
- Update README configuration table and example

## Related Issues

- Can probabbly close #30 by just providing a callback that does nothing?
